### PR TITLE
fix: typo in surprise command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Happy Birthday, Docker!
 March 2019 marks Docker's sixth year, and we thought we'd celebrate it docker-style with a birthday surprise!
 To try it out, run:
 
-`docker run -it --rm suprise`
+`docker run -it --rm surprise`
 
 Complete source can be found [here](https://github.com/docker/birthday).
 


### PR DESCRIPTION
README document had a typo in the surprise command where it was mentioned as `suprise` instead of `surprise`, which was resulting in *repository does not exist* error response from daemon.